### PR TITLE
Modernize: bump TargetFramework net5.0 → net10.0

### DIFF
--- a/BlazorRogue.csproj
+++ b/BlazorRogue.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>9.0</LangVersion>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
Phase 1 of the .NET modernization plan.

- Bumps `TargetFramework` from `net5.0` to `net10.0`
- Drops the `LangVersion 9.0` pin (defaults to latest for net10.0)
- No hosting-model or Blazor Components changes yet (those are separate follow-up phases)

**Verified:**
- `dotnet build` succeeds, 0 errors (61 pre-existing nullable warnings, down slightly from 63 due to newer nullable analysis)
- `dotnet run` serves the app natively (200 OK) with no `DOTNET_ROLL_FORWARD` workaround needed, unlike net5.0 on this machine

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
