### PR TITLE
Phase 4: eliminate all nullable reference warnings (61 -> 0)

### DIFF
--- a/Combat/Warhammer/CombatComponent.cs
+++ b/Combat/Warhammer/CombatComponent.cs
@@ -47,14 +47,14 @@ namespace BlazorRogue.Combat.Warhammer
       private set
       {
         advantage = value;
-        System.Diagnostics.Debug.WriteLine($"{Owner.Name} now has {Advantage} Advantage");
+        System.Diagnostics.Debug.WriteLine($"{Owner!.Name} now has {Advantage} Advantage");
       }
     }
 
     public void ApplyDamage(int damage)
     {
       Wounds -= damage - ToughnessBonus - ArmourPoints;
-      System.Diagnostics.Debug.WriteLine($"{Owner.Name} now has {Wounds}W");
+      System.Diagnostics.Debug.WriteLine($"{Owner!.Name} now has {Wounds}W");
     }
 
     public void GainAdvantage(int number = 1)

--- a/Configuration.cs
+++ b/Configuration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
@@ -92,12 +92,12 @@ namespace BlazorRogue
       bool special;
       var imgFloorList = new List<int>();
 
-      id = element.GetProperty("id").GetString();
+      id = GetRequiredString(element, "id");
       special = element.GetProperty("special").GetBoolean();
-      imgPrefix = element.GetProperty("img_prefix").GetString();
+      imgPrefix = GetRequiredString(element, "img_prefix");
       GetIntArray(element, "img_floor", imgFloorList);
-      charFloor = element.GetProperty("character").GetString();
-      charColor = element.GetProperty("character_color").GetString();
+      charFloor = GetRequiredString(element, "character");
+      charColor = GetRequiredString(element, "character_color");
 
       var t = new TileSet(id, TileType.Floor, imgPrefix, imgFloorList.ToArray(), null, character: charFloor, characterColor: charColor);
 
@@ -127,17 +127,17 @@ namespace BlazorRogue
       var imgSimpleEdgeNorthIndexes = new List<int>();
       var imgDecoratedEdgeNorthIndexes = new List<int>();
 
-      id = element.GetProperty("id").GetString();
-      levelType = element.GetProperty("level_type").GetString();
-      imgPrefix = element.GetProperty("img_prefix").GetString();
+      id = GetRequiredString(element, "id");
+      levelType = GetRequiredString(element, "level_type");
+      imgPrefix = GetRequiredString(element, "img_prefix");
 
       ParseIndexAndWeights(element, "img_base", imgBaseIndexes, imgBaseWeights);
       ParseIndexAndWeights(element, "img_base_edge_south", imgBaseEdgeSouthIndexes, imgBaseEdgeSouthWeights);
       GetIntArray(element.GetProperty("img_edge_north"), "simple", imgSimpleEdgeNorthIndexes);
       GetIntArray(element.GetProperty("img_edge_north"), "decorated", imgDecoratedEdgeNorthIndexes);
 
-      character = element.GetProperty("character").GetString();
-      charColor = element.GetProperty("character_color").GetString();
+      character = GetRequiredString(element, "character");
+      charColor = GetRequiredString(element, "character_color");
 
       var t = new TileSet(
           id,
@@ -175,6 +175,20 @@ namespace BlazorRogue
     {
       var imgFloorElement = element.GetProperty(property);
       listToFill.AddRange(imgFloorElement.EnumerateArray().Select(no => no.GetInt32()));
+    }
+
+    /// <summary>
+    /// Get the string value of a required JSON property. Throws if the property's value is JSON null,
+    /// since the data files aren't expected to ever supply null for these fields.
+    /// </summary>
+    private static string GetRequiredString(JsonElement element, string property)
+    {
+      return RequireNonNullString(element.GetProperty(property), property);
+    }
+
+    private static string RequireNonNullString(JsonElement stringElement, string propertyNameForError)
+    {
+      return stringElement.GetString() ?? throw new Exception($"Property '{propertyNameForError}' was expected to have a non-null string value.");
     }
 
     private static void ParseIndexAndWeights(JsonElement element, string imgName, List<int> imgArray, List<double> imgWeightArray)
@@ -224,22 +238,22 @@ namespace BlazorRogue
         out string character,
         out string characterColor)
     {
-      id = element.GetProperty("id").GetString();
-      name = element.GetProperty("name").GetString();
+      id = GetRequiredString(element, "id");
+      name = GetRequiredString(element, "name");
       weaponSkill = element.GetProperty("weaponSkill").GetInt32();
       weaponDamage = element.GetProperty("weaponDamage").GetInt32();
       toughness = element.GetProperty("toughness").GetInt32();
       armour = element.GetProperty("armour").GetInt32();
       wounds = element.GetProperty("wounds").GetInt32();
-      animationClass = element.GetProperty("animationClass").GetString();
-      character = element.GetProperty("character").GetString();
-      characterColor = element.GetProperty("character_color").GetString();
+      animationClass = GetRequiredString(element, "animationClass");
+      character = GetRequiredString(element, "character");
+      characterColor = GetRequiredString(element, "character_color");
     }
 
     private void ParseStaticDecorativeType(JsonElement element)
     {
-      string id = element.GetProperty("id").GetString();
-      string name = element.GetProperty("name").GetString();
+      string id = GetRequiredString(element, "id");
+      string name = GetRequiredString(element, "name");
 
       // Yeah, allowing image to be both a singleton, an array, and an object is me playing around :P
       var images = new Dictionary<string, string>();
@@ -256,7 +270,7 @@ namespace BlazorRogue
 
         foreach (var iElem in imageProperty.EnumerateObject())
         {
-          images.Add(iElem.Name, iElem.Value.GetString());
+          images.Add(iElem.Name, RequireNonNullString(iElem.Value, $"{imagePropertyName}.{iElem.Name}"));
         }
       }
       else if (imageProperty.ValueKind == JsonValueKind.Array)
@@ -273,7 +287,7 @@ namespace BlazorRogue
         int counter = 0;
         foreach (var iElem in imageProperty.EnumerateArray())
         {
-          images.Add($"{counter}", iElem.GetString());
+          images.Add($"{counter}", RequireNonNullString(iElem, imagePropertyName));
           counter++;
         }
       }
@@ -285,22 +299,22 @@ namespace BlazorRogue
          * Tag will be set to ""
          */
 
-        images.Add("", imageProperty.GetString());
+        images.Add("", RequireNonNullString(imageProperty, imagePropertyName));
       }
       else
       {
         throw new Exception($"{imagePropertyName} should be either a single string, an array of strings, or an object with string, string pairs.");
       }
 
-      string infoText = element.GetProperty("info_text").GetString();
+      string infoText = GetRequiredString(element, "info_text");
       int verticalOffset = element.GetProperty("vertical_offset").GetInt32();
-      string character = element.GetProperty("character").GetString();
-      string characterColor = element.GetProperty("character_color").GetString();
+      string character = GetRequiredString(element, "character");
+      string characterColor = GetRequiredString(element, "character_color");
 
       string imgFolder = defaultStaticDecorationImgFolder;
       if (element.TryGetProperty("img_folder", out JsonElement imgFolderElement))
       {
-        imgFolder = imgFolderElement.GetString();
+        imgFolder = RequireNonNullString(imgFolderElement, "img_folder");
       }
 
       bool blocking = false;

--- a/DungeonGenerator.cs
+++ b/DungeonGenerator.cs
@@ -290,13 +290,13 @@ namespace BlazorRogue
 
       map.ForEachTile(initFill);
 
-      bool[,] newmap = null;
+      bool[,]? newmap = null;
       Action<int, int> generation1Fill = (x, y) =>
            {
              if (SurroundingWallNumberWithinN(genmap, x, y, 1) >= 5 || SurroundingWallNumberWithinN(genmap, x, y, 2) <= 1)
-               newmap[x, y] = true;
+               newmap![x, y] = true;
              else
-               newmap[x, y] = false;
+               newmap![x, y] = false;
            };
 
       for (int i = 0; i < 4; i++)
@@ -311,9 +311,9 @@ namespace BlazorRogue
       Action<int, int> generation2Fill = (x, y) =>
            {
              if (SurroundingWallNumberWithinN(genmap, x, y, 1) >= 5)
-               newmap[x, y] = true;
+               newmap![x, y] = true;
              else
-               newmap[x, y] = false;
+               newmap![x, y] = false;
            };
 
       for (int i = 0; i < 3; i++)

--- a/Game.cs
+++ b/Game.cs
@@ -11,7 +11,9 @@ namespace BlazorRogue
 
     public DungeonGenerator DungeonGenerator { get; private set; }
     public Map Map { get; private set; }
-    public static SoundManager SoundManager { get; set; }
+    // Set up before the first Game instance is constructed; null! avoids forcing nullable-checks
+    // throughout the codebase for a value that's always non-null in practice.
+    public static SoundManager SoundManager { get; set; } = null!;
     public FightingSystem FightingSystem { get; private set; }
     public Configuration Configuration { get; private set; }
     public EffectsSystem EffectsSystem { get; private set; }

--- a/GameObjects/Chest.cs
+++ b/GameObjects/Chest.cs
@@ -44,7 +44,7 @@ namespace BlazorRogue.GameObjects
         case ChestState.Closed:
           return "Closed";
         case ChestState.Open:
-          return $"{chest.InventoryComponent.Gold} gold";
+          return $"{chest.InventoryComponent!.Gold} gold";
         default:
           throw new Exception($"Unknown ChestState: {chest.State}");
       }
@@ -70,7 +70,7 @@ namespace BlazorRogue.GameObjects
           case ChestState.Open:
             if (chest.InventoryComponent.Gold > 0)
             {
-              References.Map.Player.InventoryComponent.Gold += chest.InventoryComponent.Gold;
+              References.Map.Player.InventoryComponent!.Gold += chest.InventoryComponent.Gold;
               chest.InventoryComponent.Gold = 0;
               References.SoundManager.PlayPickupMoney();
             }
@@ -99,7 +99,7 @@ namespace BlazorRogue.GameObjects
           img = sdot.ImageVariants["closed"];
           break;
         case ChestState.Open:
-          if (InventoryComponent.Gold > 0)
+          if (InventoryComponent!.Gold > 0)
           {
             img = sdot.ImageVariants["open_full"];
           }
@@ -111,7 +111,7 @@ namespace BlazorRogue.GameObjects
           break;
       }
 
-      map.Decorations[x, y].Add(new Decoration(this, img, sdot.ImgFolder) { Character = sdot.Character, CharacterColor = sdot.CharacterColor, OnUse = UseableComponent.Use });
+      map.Decorations[x, y].Add(new Decoration(this, img, sdot.ImgFolder) { Character = sdot.Character, CharacterColor = sdot.CharacterColor, OnUse = UseableComponent!.Use });
       //TODO:Cleanup
       //// add a separate decoration for onUse (without own graphic) to interact with the door
       //map.Decorations[x, y].Add(new Decoration(this, null) { OnUse = UseableComponent.Use });

--- a/GameObjects/Door.cs
+++ b/GameObjects/Door.cs
@@ -63,7 +63,7 @@ namespace BlazorRogue.GameObjects
       }
 
       // add a button (without own graphic) to interact with the door
-      map.Decorations[x, y].Add(new Decoration(this, null) { OnUse = UseableComponent.Use });
+      map.Decorations[x, y].Add(new Decoration(this, null) { OnUse = UseableComponent!.Use });
       // TODO: Not too happy about this; seems wrong to add mouse interaction decentralized like this, and call UseableComponent.Use from here
     }
 

--- a/GameObjects/StaticDecorativeObject.cs
+++ b/GameObjects/StaticDecorativeObject.cs
@@ -23,10 +23,12 @@ namespace BlazorRogue.GameObjects
     {
       if (imageTag != null)
       {
-        if (!staticDecorativeObjectType.ImageVariants.TryGetValue(imageTag, out image))
+        if (!staticDecorativeObjectType.ImageVariants.TryGetValue(imageTag, out string? imageVariant))
         {
           throw new ArgumentException($"{nameof(imageTag)} must be a key into {nameof(staticDecorativeObjectType.ImageVariants)}.");
         }
+
+        image = imageVariant;
       }
       else
       {

--- a/Map.cs
+++ b/Map.cs
@@ -14,7 +14,9 @@ namespace BlazorRogue
 
     public TileSet DungeonWallSet { get; private set; }
     public Game Game { get; }
-    public Moveable Player { get; private set; }
+    // Set via AddPlayer() shortly after Map construction (DungeonGenerator always calls it before
+    // the map is used); null! avoids forcing nullable-checks on every consumer of this property.
+    public Moveable Player { get; private set; } = null!;
     public const int PlayerSightRadius = 6;
     public const int PlayerSightRadiusSquared = PlayerSightRadius * PlayerSightRadius;
 
@@ -234,7 +236,7 @@ namespace BlazorRogue
       this.monsters.Add(monster);
     }
 
-    private void MonsterKilled(object sender, EventArgs e)
+    private void MonsterKilled(object? sender, EventArgs e)
     {
       var killedMonster = sender as Moveable;
       if (killedMonster == null)

--- a/Pages/Indoor.razor
+++ b/Pages/Indoor.razor
@@ -200,13 +200,13 @@
             {
                 <li>@debugInfo</li>
             }
-            <li>Hitpoints: @game.Map.Player.CombatComponent.Wounds </li>
-            <li>Advantage?: @game.Map.Player.CombatComponent.Advantage </li>
-            <li>Armour: @game.Map.Player.CombatComponent.ArmourPoints</li>
-            <li>Toughness: @game.Map.Player.CombatComponent.Toughness</li>
-            <li>Weaponskill: @game.Map.Player.CombatComponent.WeaponSkill</li>
-            <li>Damage: @game.Map.Player.CombatComponent.WeaponDamage</li>
-            <li>Gold: @game.Map.Player.InventoryComponent.Gold</li>
+            <li>Hitpoints: @game.Map.Player.CombatComponent!.Wounds </li>
+            <li>Advantage?: @game.Map.Player.CombatComponent!.Advantage </li>
+            <li>Armour: @game.Map.Player.CombatComponent!.ArmourPoints</li>
+            <li>Toughness: @game.Map.Player.CombatComponent!.Toughness</li>
+            <li>Weaponskill: @game.Map.Player.CombatComponent!.WeaponSkill</li>
+            <li>Damage: @game.Map.Player.CombatComponent!.WeaponDamage</li>
+            <li>Gold: @game.Map.Player.InventoryComponent!.Gold</li>
         </ul>
     </div>
 </div>
@@ -255,7 +255,7 @@
 
   public void OnClick(Decoration decoration)
   {
-      decoration.OnUse();
+      decoration.OnUse?.Invoke();
       // NOTE: Rerender only gameobject? or rerender every decoration in tile...? Going for the latter, right now...
       //       When I begin to do effecs, I may need to revisit this...
       game.Map.UpdateBlocksLight(decoration.GameObject.x, decoration.GameObject.y, recomputeVisibility: true);

--- a/References.cs
+++ b/References.cs
@@ -7,9 +7,11 @@ namespace BlazorRogue
 {
   public static class References
   {
-    public static Map Map { get; internal set; }
-    public static Configuration Configuration { get; internal set; }
-    public static SoundManager SoundManager { get; internal set; }
-    public static EffectsSystem EffectsSystem { get; internal set; }
+    // These are set up during Game's constructor, before any game logic runs; null! avoids
+    // forcing nullable-checks throughout the codebase for values that are always non-null in practice.
+    public static Map Map { get; internal set; } = null!;
+    public static Configuration Configuration { get; internal set; } = null!;
+    public static SoundManager SoundManager { get; internal set; } = null!;
+    public static EffectsSystem EffectsSystem { get; internal set; } = null!;
   }
 }

--- a/UseableComponent.cs
+++ b/UseableComponent.cs
@@ -16,7 +16,7 @@ namespace BlazorRogue
 
     public void Use()
     {
-      onUse.Invoke(Owner);
+      onUse.Invoke(Owner!);
     }
   }
 }


### PR DESCRIPTION
## Phase 4 (final phase): Nullable reference warning cleanup

Eliminates all 61 remaining nullable-reference (`CS86xx`) warnings, leaving a fully clean build (0 warnings, 0 errors). This was the last remaining phase of the .NET 5 -> .NET 10 modernization plan.

### Changes by category

**Configuration.cs** (bulk of the warnings, ~35)
- Added `GetRequiredString(JsonElement element, string property)` and `RequireNonNullString(JsonElement stringElement, string propertyNameForError)` helpers that throw a clear, descriptive exception if a required JSON string field is null, instead of silently returning `string?`.
- Replaced all `.GetProperty(...).GetString()` call sites for required fields across `ParseFloorSetType`, `ParseWallSetType`, `ParseMoveable`, `ParseStaticDecorativeType`.

**References.cs, Game.cs, Map.cs** (static/late-init singletons)
- `Map`, `Configuration`, `SoundManager`, `EffectsSystem` (References.cs), `SoundManager` (Game.cs), `Player` (Map.cs) are all set during `Game`'s constructor / `AddPlayer()` before any use. Annotated with `= null!;` plus an explanatory comment rather than making them nullable, which would force null-checks throughout many consumers.
- `Map.MonsterKilled` signature updated to `object? sender` to match `EventHandler`'s delegate signature (fixes CS8622).

**CombatComponent.cs, UseableComponent.cs**
- Null-forgiving operator (`Owner!`, `onUse.Invoke(Owner!)`) at use sites, consistent with the existing `GameObject.cs` `Owner!.Kill()` precedent — `Owner` is always set via `SetOwner` immediately after construction.

**Chest.cs, Door.cs**
- Null-forgiving operator on `InventoryComponent!`/`UseableComponent!` access — both object types are always constructed with these components non-null.

**StaticDecorativeObject.cs**
- Refactored a `TryGetValue` pattern to assign into a local `out string? imageVariant` variable first, then assign to the `image` field after the null check. Local variables get precise flow-sensitive null tracking; fields don't.

**DungeonGenerator.cs**
- `bool[,] newmap` -> `bool[,]? newmap`, with `newmap!` inside the two fill closures (`generation1Fill`, `generation2Fill`) where it's guaranteed to already be assigned.

**Pages/Indoor.razor** (3 remaining warnings)
- Null-forgiving operator on `Player.CombatComponent`/`Player.InventoryComponent` access (Player is always constructed with both components).
- `OnClick` now uses `decoration.OnUse?.Invoke()` since `Decoration.OnUse` is a genuinely optional `Action?` (not every decoration has a use-action) — this is a small behavioral improvement (no-op instead of a potential `NullReferenceException`) rather than just a warning suppression.

### Verification
- `dotnet build --no-incremental` -> **0 warnings, 0 errors** (was 61 warnings at the start of this session, then 24 after the Configuration.cs pass, now 0).
- `dotnet run` + `curl` -> 200 OK; verified the debug panel renders `Hitpoints: 20`, `Gold: 0` etc. correctly, confirming none of the null-forgiving changes broke runtime behavior.

This completes all 5 phases of the modernization plan (TFM bump, minimal hosting, unified Blazor Components, nullable cleanup, GitHub Actions CI).
