### PR TITLE
Auto-fallback to ASCII renderer when tileset is missing

### DIFF
--- a/Pages/Indoor.razor
+++ b/Pages/Indoor.razor
@@ -1,7 +1,11 @@
 ﻿@page "/"
 
+@using System.IO
+@using System.Linq
+@using Microsoft.AspNetCore.Hosting
 @using Microsoft.JSInterop
 @inject IJSRuntime JsRuntime;
+@inject IWebHostEnvironment WebHostEnvironment;
 <!--  PICKUP:
     Next steps,
         * (Bug) Seems that a monster can both move and attack - if Player waits (5) with one tile in between monster and player, the monster can still attack?
@@ -234,6 +238,17 @@
 
   protected override void OnInitialized()
   {
+      // Fall back to the ASCII renderer by default if the (licensed, not
+      // included in the repo) Ultimate Fantasy tileset hasn't been placed
+      // under wwwroot/img - otherwise the tileset view would just render
+      // empty/broken tiles. uf_terrain is used pervasively (floors/walls),
+      // so its presence is a good proxy for "the tileset is installed".
+      string tilesetProbeDirectory = Path.Combine(WebHostEnvironment.WebRootPath, "img", "uf_terrain");
+      if (!Directory.Exists(tilesetProbeDirectory) || !Directory.EnumerateFiles(tilesetProbeDirectory).Any())
+      {
+          renderAscii = true;
+      }
+
       int optimalXOffset = game.Map.Player.x - windowWidth / 2;
       windowXOffset = Math.Clamp(optimalXOffset, 0, game.Map.Width - windowWidth);
 

--- a/README.md
+++ b/README.md
@@ -33,9 +33,16 @@ The same scene rendered in the ASCII renderer:
 
 ## Building
 
-Follow the instructions on [Get started with ASP.NET Core Blazor](https://docs.microsoft.com/en-us/aspnet/core/blazor/get-started) to get a working build environment for Blazor for either VS code or Visual Studio. 
+Requires the [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) (or later). BlazorRogue is an ASP.NET Core Blazor Web App using the unified Razor Components hosting model with interactive server-side rendering.
 
-(This very project started with  a `dotnet new blazorserverside -o WebApplication1`, as can probably still be seen here and there.)
+```
+dotnet build
+dotnet run
+```
+
+By default the app listens on `https://localhost:5001` and `http://localhost:5000` (see `Properties/launchSettings.json`); open either URL in a browser. The game auto-detects whether the tileset (see below) is present under `wwwroot/img/` and falls back to its built-in ASCII renderer automatically if it isn't; either way, you can also switch renderers manually at any time via the "Switch mode" button in-game.
+
+(This very project started with a `dotnet new blazorserverside -o WebApplication1`, as can probably still be seen here and there.)
 
 ## Tileset
 


### PR DESCRIPTION
## Auto-detect missing tileset and fall back to ASCII renderer

The game previously always defaulted to tileset rendering mode regardless of whether the (licensed, not included in this repo) Ultimate Fantasy tileset assets were actually present under `wwwroot/img/`. Without the tileset, this rendered empty/broken tiles rather than something playable - the user had to already know about, and manually click, the "Switch mode" button to get the ASCII renderer.

### Change
`Indoor.razor` now checks for `wwwroot/img/uf_terrain` (used pervasively for floors/walls, so a good proxy for "the tileset is installed") in `OnInitialized` via `IWebHostEnvironment`, and defaults `renderAscii` to `true` if that folder is missing or empty. Users can still switch renderers manually at any time via the existing "Switch mode" button - this only changes the *default* on first load.

Also corrects the README's Building section, which described this auto-fallback behavior even though it didn't exist in the app yet.

### Verification
- `dotnet build` -> 0 warnings, 0 errors.
- With `wwwroot/img/uf_terrain` present: rendered page uses 48px tiles (tileset mode).
- With `uf_terrain` temporarily renamed away: same page renders with 20px tiles (ASCII mode) automatically, no manual toggle needed.
- Restored the tileset folder afterwards.
