### PR TITLE
Overhaul README, add MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Troels Damgaard
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,35 @@
 # BlazorRogue
 
 [![Build](https://github.com/dontrolle/BlazorRogue/actions/workflows/build.yml/badge.svg)](https://github.com/dontrolle/BlazorRogue/actions/workflows/build.yml)
+[![.NET 10](https://img.shields.io/badge/.NET-10-512BD4)](https://dotnet.microsoft.com/download/dotnet/10.0)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-A small rogue-like built from the bottom-up in a little game engine I built on C#/Blazor. Has a tileset renderer using the the beautiful [Ultimate Fantasy Tileset tiles from Oryx](https://www.oryxdesignlab.com/ultimatefantasy), and a custom-built ASCII renderer.
+A small rogue-like built from the bottom up in a custom game engine on C#/Blazor. Features a tileset renderer using the beautiful [Ultimate Fantasy Tileset from Oryx](https://www.oryxdesignlab.com/ultimatefantasy), and a custom-built ASCII renderer, switchable at any time.
 
-### Features
+## Table of contents
 
-* Dungeon generation, a variety of monsters (animated using CSS-animations), mouse-over descriptions, sounds and music, screen-shake effect, useable environment, field of vision, basic combat (should be balanced at some point), ...
+- [Features](#features)
+- [Screenshots](#screenshots)
+- [Getting started](#getting-started)
+- [How to play](#how-to-play)
+- [Tileset](#tileset)
+- [Project structure](#project-structure)
+- [Architecture](#architecture)
+- [Game data / configuration](#game-data--configuration)
+- [Contributing](#contributing)
+- [License](#license)
 
-* Engine supports json-configuration for most visuals, audio and attributes for entities, as well as weights and config for map generation.
+## Features
 
-* Supports tileset renderer - uses a number of tiles from the splendid UF Tileset, as well as an ASCII renderer in that old school format (though with colors).
-* Allows fast (client-side) switching between tileset and ASCII rendering.
+- Procedural dungeon generation.
+- A variety of monsters, animated using CSS animations, with mouse-over descriptions.
+- Sounds and music, plus a screen-shake effect on hits.
+- Useable environment objects (doors, chests) and field-of-view/vision.
+- Basic combat, driven by a Warhammer-inspired ruleset.
+- A tileset renderer (using the Ultimate Fantasy Tileset) and a from-scratch ASCII renderer (old-school format, with colors), switchable client-side at any time - and auto-selected on load based on whether tileset assets are present.
+- Almost everything (monster/hero stats, floor/wall sets, decorations, map generation weights) is data-driven via JSON, rather than hardcoded — see [Game data / configuration](#game-data--configuration).
 
-### Screenshots 
+## Screenshots
 
 A partially explored sandy dungeon with a number of monsters chasing:
 
@@ -31,23 +47,91 @@ The same scene rendered in the ASCII renderer:
 
 ![BlazorRogue Screenshot 3 - in ASCII](/img/BlazorRogue3_ascii.PNG)
 
-## Building
+## Getting started
 
-Requires the [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) (or later). BlazorRogue is an ASP.NET Core Blazor Web App using the unified Razor Components hosting model with interactive server-side rendering.
+### Prerequisites
+
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) or later.
+- No database, no external services, no additional tooling required.
+
+### Clone, build, run
 
 ```
+git clone https://github.com/dontrolle/BlazorRogue.git
+cd BlazorRogue
 dotnet build
 dotnet run
 ```
 
-By default the app listens on `https://localhost:5001` and `http://localhost:5000` (see `Properties/launchSettings.json`); open either URL in a browser. The game auto-detects whether the tileset (see below) is present under `wwwroot/img/` and falls back to its built-in ASCII renderer automatically if it isn't; either way, you can also switch renderers manually at any time via the "Switch mode" button in-game.
+By default the app listens on `https://localhost:5001` and `http://localhost:5000` (see `Properties/launchSettings.json`) — open either URL in a browser to play. There's no database or seed step; a fresh dungeon is generated on every page load.
+
+There is no test project in this repository (`dotnet test` has nothing to run) and no separate lint step — rely on `.editorconfig` conventions and the compiler's nullable-reference-type warnings (the build is currently warning-free; please keep it that way). CI runs `dotnet build` on every push/PR to `master` via GitHub Actions (`.github/workflows/build.yml`).
 
 (This very project started with a `dotnet new blazorserverside -o WebApplication1`, as can probably still be seen here and there.)
 
+## How to play
+
+| Action | Keys |
+|---|---|
+| Move / attack (8-directional) | Numpad, or `qweasdzxc` |
+| Use (open door, chest, etc.) | `Shift` + move towards the object |
+| Set keyboard focus on the map | Click the map |
+| Start a new game | Refresh the page |
+| Switch tileset/ASCII rendering | "Switch mode" button (left panel) |
+
 ## Tileset
 
-This project employs the excellent [Ultimate Fantasy Tileset](https://www.oryxdesignlab.com/ultimatefantasy). I own the tileset and have the commercial license, but the tileset graphics used by this project have been removed from this repo, as it is part of the license-agreement that they should be protected from copying.
+This project employs the excellent [Ultimate Fantasy Tileset](https://www.oryxdesignlab.com/ultimatefantasy). The author owns the tileset under a commercial license, but the tileset graphics used by this project have been removed from this repo (and are excluded via `.gitignore`), since the license agreement requires them to be protected from copying.
 
-If you own the UF Tileset, you can put the subfolders of the `uf_split` folder in the UF Tileset in the `wwwroot/img/`-folder, and BlazorRogue will be able employ the tileset.
+If you own the UF Tileset, put the subfolders of the `uf_split` folder from the tileset into the `wwwroot/img/` folder, and BlazorRogue will use it automatically. Without it, the game automatically falls back to the built-in ASCII renderer — no setup needed to get playing.
 
-In some unknown future, I might make an effort to make a release where the tileset is suitably protected. Don't wait for it, though, as this is an on-and-off hobby-project of mine to play around with Blazor and roguelikes. ;)
+## Project structure
+
+```
+BlazorRogue.csproj / Program.cs   Minimal-hosting entry point, unified Blazor Components hosting
+App.razor / Routes.razor          Root HTML shell + router
+Pages/                            Blazor pages (Indoor.razor is the main game view)
+Shared/                           Shared Razor components
+GameObjects/                      GameObject and its subclasses (Moveable, Door, Chest, ...)
+Combat/                           Combat system, incl. the Warhammer-inspired ruleset (Combat/Warhammer/)
+AI/                               Monster AI components
+Vision/                           Field-of-view implementation
+Entities/                         Type definitions parsed from configuration (MoveableType, etc.)
+Data/                             JSON game data: monsters, heroes, floorsets, wallsets, decorations
+Configuration.cs                  Parses Data/*.json into the strongly-typed Entities
+Game.cs / Map.cs / References.cs  Core game/session state (see Architecture below)
+wwwroot/                          Static assets: CSS, JS interop, sounds, tileset images (gitignored)
+```
+
+## Architecture
+
+- **`Game`** (`Game.cs`) is the root object built once per game session. It owns the `DungeonGenerator`, `Map`, `FightingSystem`, `Configuration`, and `EffectsSystem`.
+- **`References`** (`References.cs`) is a static service-locator-style holder for the current `Map`, `Configuration`, `SoundManager`, and `EffectsSystem`, set up during `Game`'s constructor. Code throughout the engine (e.g. `GameObject.Kill()`) reaches these statics directly rather than receiving them via DI/constructor injection.
+- **`Configuration`** (`Configuration.cs`) parses all game data from JSON files under `Data/` into strongly-typed dictionaries (`MoveableType`, `StaticDecorativeObjectType`, `TileSet`). Nearly all visual/audio/combat-stat tuning is data-driven through these files rather than hardcoded.
+- **Entity/component model**: `GameObject` (`GameObjects/GameObject.cs`) is the abstract base for everything placed on the map (`Moveable`, `Door`, `Chest`, `Torch`, `HalfWall`, `CaveEdge`, `StaticDecorativeObject`). Behavior is composed via optional `Component` subclasses (`AIComponent`, `CombatComponent`, `UseableComponent`, `InventoryComponent`) attached at construction — a `Component` always knows its `Owner` via `SetOwner`.
+- **Map & rendering**: `Map.cs` holds the `Tile` grid; `DungeonGenerator.cs` procedurally builds it. `Vision/` implements field-of-view (the Adam Milne visibility algorithm). Rendering is split between a tileset path and an ASCII path — `GameObject.Render(Map map)` is the per-object hook, and `Pages/Indoor.razor` is the Blazor page that renders the grid, switching between tileset and ASCII based on the `renderAscii` flag.
+- **Combat**: lives under `Combat/`, with a specific ruleset in `Combat/Warhammer/` (`FightingSystem`, `Dice`) — combat stats (weapon skill, damage, toughness, armour, wounds) are parsed from the same `Configuration` JSON files.
+- **Hosting**: `Program.cs` uses the minimal hosting API plus the unified Blazor Components model (`AddRazorComponents().AddInteractiveServerComponents()` / `MapRazorComponents<App>().AddInteractiveServerRenderMode()`). `App.razor` is the root HTML shell (`<HeadOutlet>` + `<Routes>`), and `Routes.razor` holds the `<Router>`.
+
+A more detailed, AI-agent-oriented version of this section (including gotchas like the `~/`-style Tag Helper URL resolution not working inside `.razor` components) lives in [`.github/copilot-instructions.md`](.github/copilot-instructions.md) — worth a read before making structural changes.
+
+## Game data / configuration
+
+Most game content is data, not code — new monsters, heroes, floor/wall sets, and decorations can usually be added without touching C#:
+
+- `Data/monsters.json`, `Data/heroes.json` — combat stats, AI behavior, sprites/animations.
+- `Data/floorsets.json`, `Data/wallsets.json` — tileset mappings and map-generation weights.
+- `Data/decorations.json` — static decorative objects (torches, carpets, etc.).
+
+These are parsed in `Configuration.cs` via a `Parse*Type` method per entity kind — follow the existing pattern (and the `GetRequiredString`/`RequireNonNullString` helpers for required fields) when adding a new data-driven concept.
+
+## Contributing
+
+- `master` is protected: everyone (including the maintainer) needs to go through a pull request; CI (`dotnet build`) must pass before merging.
+- Please keep the build warning-free — nullable reference types are enabled project-wide.
+- Since there's no test suite yet, please describe how you manually verified a change (e.g. build + a screenshot or a description of in-browser testing) in your PR description.
+- Small, focused PRs are preferred over large ones, especially for anything touching rendering or the hosting model — those are the areas most likely to have subtle runtime-only breakage that `dotnet build` won't catch.
+
+## License
+
+This project's code is licensed under the [MIT License](LICENSE). The Ultimate Fantasy Tileset assets referenced in [Tileset](#tileset) are © Oryx Design Lab and are **not** covered by this license — they are proprietary, excluded from this repo, and require their own separate license to use.


### PR DESCRIPTION
## Overhaul README, add MIT LICENSE

Restructures `README.md` to be a much better entry point for developers who want to clone, build, and contribute to this repo, and adds a license (previously missing).

### README changes
- Added a table of contents.
- Added a **Getting Started** section: prerequisites (.NET 10 SDK) and concrete clone/build/run steps.
- Added a **How to Play** section documenting controls (movement, use, new game, mode switch) - previously this was only visible in-app, not in the README.
- Added a **Project Structure** section: an annotated top-level file/folder tree.
- Added an **Architecture** section, condensed from `.github/copilot-instructions.md`, with a pointer to that file for full depth (avoids duplicating/drifting the two out of sync).
- Added a **Game data / configuration** section explaining the `Data/*.json` files and how to add new data-driven content.
- Added a **Contributing** section: branch protection (PRs required for everyone), CI expectations, no test suite yet.
- Added badges for .NET version and license alongside the existing build badge.
- Added a **License** section, clarifying the tileset assets are separately licensed (Oryx) and not covered by this repo's license.

### LICENSE
- Added an MIT license for the code in this repo (there was previously no LICENSE file at all).

Note: intentionally does **not** include a "Roadmap / known issues" section (extracted from a TODO comment in `Indoor.razor`) - kept private per the repo owner's preference, not ready to publish yet.
