### PR TITLE
Add xUnit test project covering core game logic

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,7 +17,7 @@ dotnet build
 can wire up `References.SoundManager` etc.) and mirrors `Data/*.json` into its own output directory
 since `Configuration.Parse()` reads them via relative paths. There is no separate lint step (rely on
 `.editorconfig` conventions and compiler warnings — nullable reference types are enabled, so watch
-for new nullability warnings, currently ~61 pre-existing).
+for new nullability warnings).
 
 CI runs `dotnet build` then `dotnet test` on every push/PR to `master` via GitHub Actions
 (`.github/workflows/build.yml`).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,11 +11,15 @@ ASCII renderer, switchable client-side.
 dotnet build
 ```
 
-There is no test project in this repository, so there is nothing to `dotnet test`. There is also
-no separate lint step (rely on `.editorconfig` conventions and compiler warnings — nullable
-reference types are enabled, so watch for new nullability warnings, currently ~61 pre-existing).
+`BlazorRogue.Tests` is an xUnit test project covering core, UI-independent logic (dice/combat math,
+`Configuration` JSON parsing, `Map` geometry, and dungeon-generation smoke tests). Run it with
+`dotnet test`. It references `BlazorRogue.csproj` directly (`InternalsVisibleTo` is set up so tests
+can wire up `References.SoundManager` etc.) and mirrors `Data/*.json` into its own output directory
+since `Configuration.Parse()` reads them via relative paths. There is no separate lint step (rely on
+`.editorconfig` conventions and compiler warnings — nullable reference types are enabled, so watch
+for new nullability warnings, currently ~61 pre-existing).
 
-CI runs `dotnet build` on every push/PR to `master` via GitHub Actions
+CI runs `dotnet build` then `dotnet test` on every push/PR to `master` via GitHub Actions
 (`.github/workflows/build.yml`).
 
 To run locally, follow the ASP.NET Core Blazor "Get started" instructions. The tileset image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,3 +22,6 @@ jobs:
 
       - name: Build
         run: dotnet build --no-restore --configuration Release
+
+      - name: Test
+        run: dotnet test --no-build --configuration Release

--- a/BlazorRogue.Tests/AssemblyInfo.cs
+++ b/BlazorRogue.Tests/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+using Xunit;
+
+// This codebase uses static holders (see BlazorRogue.References) rather than DI for several
+// cross-cutting services (Map, Configuration, SoundManager, EffectsSystem). Several tests mutate
+// these statics as a side effect of constructing game objects (e.g. `new Game()`), so we disable
+// test parallelization within this assembly to avoid cross-test interference.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/BlazorRogue.Tests/BlazorRogue.Tests.csproj
+++ b/BlazorRogue.Tests/BlazorRogue.Tests.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BlazorRogue.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Configuration.Parse() reads these JSON files via relative "Data\..." paths at the current
+         working directory, so mirror them into the test output directory too. -->
+    <None Include="..\Data\**\*.json" LinkBase="Data">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/BlazorRogue.Tests/Combat/CombatComponentTests.cs
+++ b/BlazorRogue.Tests/Combat/CombatComponentTests.cs
@@ -1,0 +1,105 @@
+using BlazorRogue.Combat.Warhammer;
+using BlazorRogue.Entities;
+
+namespace BlazorRogue.Tests.Combat
+{
+  public class CombatComponentTests
+  {
+    private static Moveable CreateMoveable(int weaponSkill = 30, int weaponDamage = 8, int toughness = 30, int armour = 2, int wounds = 10)
+    {
+      var type = new MoveableType(
+          id: "test",
+          name: "Test Dummy",
+          animationClass: "animated_test",
+          asciiCharacter: "t",
+          asciiColour: "white",
+          weaponSkill: weaponSkill,
+          weaponDamage: weaponDamage,
+          toughness: toughness,
+          armour: armour,
+          wounds: wounds);
+
+      return new Moveable(0, 0, aIComponent: null, type);
+    }
+
+    [Fact]
+    public void ToughnessBonus_IsToughnessDividedByTen()
+    {
+      var moveable = CreateMoveable(toughness: 35);
+      Assert.Equal(3, moveable.CombatComponent!.ToughnessBonus);
+    }
+
+    [Fact]
+    public void ApplyDamage_ReducesWoundsByDamageMinusToughnessBonusAndArmour()
+    {
+      // toughness 30 => bonus 3, armour 2 soaks 5 of the 8 damage, leaving 3 wounds lost
+      var moveable = CreateMoveable(toughness: 30, armour: 2, wounds: 10);
+      moveable.CombatComponent!.ApplyDamage(8);
+
+      Assert.Equal(7, moveable.CombatComponent.Wounds);
+    }
+
+    [Fact]
+    public void ApplyDamage_BelowSoakThreshold_IncreasesWounds()
+    {
+      // NOTE: documents current (possibly unintended) behavior - when soaked damage (toughness
+      // bonus + armour) exceeds the raw damage, wounds actually go up rather than being floored at 0.
+      var moveable = CreateMoveable(toughness: 30, armour: 2, wounds: 10);
+      moveable.CombatComponent!.ApplyDamage(1);
+
+      Assert.Equal(14, moveable.CombatComponent.Wounds);
+    }
+
+    [Fact]
+    public void ApplyDamage_KillsOwnerWhenWoundsReachZero()
+    {
+      var moveable = CreateMoveable(toughness: 0, armour: 0, wounds: 5);
+      var killed = false;
+      moveable.GameObjectKilled += (_, _) => killed = true;
+
+      moveable.CombatComponent!.ApplyDamage(5);
+
+      Assert.True(killed);
+      Assert.True(moveable.CombatComponent.Wounds <= 0);
+    }
+
+    [Fact]
+    public void GainAdvantage_IsCappedAtEight()
+    {
+      var moveable = CreateMoveable();
+      moveable.CombatComponent!.GainAdvantage(20);
+
+      Assert.Equal(8, moveable.CombatComponent.Advantage);
+    }
+
+    [Fact]
+    public void GainAdvantage_Accumulates()
+    {
+      var moveable = CreateMoveable();
+      moveable.CombatComponent!.GainAdvantage();
+      moveable.CombatComponent.GainAdvantage(2);
+
+      Assert.Equal(3, moveable.CombatComponent.Advantage);
+    }
+
+    [Fact]
+    public void ResetAdvantage_SetsAdvantageToZero()
+    {
+      var moveable = CreateMoveable();
+      moveable.CombatComponent!.GainAdvantage(4);
+      moveable.CombatComponent.ResetAdvantage();
+
+      Assert.Equal(0, moveable.CombatComponent.Advantage);
+    }
+
+    [Fact]
+    public void LooseAdvantage_DecrementsByOne()
+    {
+      var moveable = CreateMoveable();
+      moveable.CombatComponent!.GainAdvantage(4);
+      moveable.CombatComponent.LooseAdvantage();
+
+      Assert.Equal(3, moveable.CombatComponent.Advantage);
+    }
+  }
+}

--- a/BlazorRogue.Tests/Combat/DiceTests.cs
+++ b/BlazorRogue.Tests/Combat/DiceTests.cs
@@ -1,0 +1,73 @@
+using System;
+using BlazorRogue.Combat;
+
+namespace BlazorRogue.Tests.Combat
+{
+  public class DiceTests
+  {
+    [Fact]
+    public void RollD100_IsAlwaysWithinValidRange()
+    {
+      for (int i = 0; i < 1000; i++)
+      {
+        var roll = Dice.RollD100();
+        Assert.InRange(roll, 1, 100);
+      }
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(101)]
+    [InlineData(-5)]
+    public void ReverseD100_ThrowsForInvalidValues(int invalidRoll)
+    {
+      Assert.Throws<ArgumentException>(() => Dice.ReverseD100(invalidRoll));
+    }
+
+    [Theory]
+    [InlineData(100, 100)]
+    [InlineData(1, 10)]
+    [InlineData(45, 54)]
+    [InlineData(10, 1)]
+    [InlineData(99, 99)]
+    public void ReverseD100_SwapsTensAndUnits(int roll, int expected)
+    {
+      Assert.Equal(expected, Dice.ReverseD100(roll));
+    }
+
+    [Theory]
+    [InlineData(45, 4, 5)]
+    [InlineData(1, 0, 1)]
+    [InlineData(100, 10, 0)]
+    [InlineData(10, 1, 0)]
+    public void GetD100Digits_ReturnsTensAndRemainder(int roll, int expectedTens, int expectedRemainder)
+    {
+      var digits = Dice.GetD100Digits(roll);
+      Assert.Equal(expectedTens, digits.Item1);
+      Assert.Equal(expectedRemainder, digits.Item2);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(101)]
+    public void GetD100Digits_ThrowsForInvalidValues(int invalidRoll)
+    {
+      Assert.Throws<ArgumentException>(() => Dice.GetD100Digits(invalidRoll));
+    }
+
+    [Theory]
+    [InlineData(1, 50, 5)]   // roll's tens digit 0, skill's tens digit 5 => 5 - 0
+    [InlineData(50, 50, 0)]  // equal tens digits
+    [InlineData(91, 20, -7)] // skill tens 2, roll tens 9 => 2 - 9
+    public void GetSuccessLevel_ComparesTensDigitsOfRollAndSkill(int d100Roll, int skillLevel, int expected)
+    {
+      Assert.Equal(expected, Dice.GetSuccessLevel(d100Roll, skillLevel));
+    }
+
+    [Fact]
+    public void GetSuccessLevel_ThrowsForInvalidRoll()
+    {
+      Assert.Throws<ArgumentException>(() => Dice.GetSuccessLevel(0, 50));
+    }
+  }
+}

--- a/BlazorRogue.Tests/Combat/FightingSystemTests.cs
+++ b/BlazorRogue.Tests/Combat/FightingSystemTests.cs
@@ -1,0 +1,76 @@
+using BlazorRogue.Combat.Warhammer;
+using BlazorRogue.Entities;
+
+namespace BlazorRogue.Tests.Combat
+{
+  public class FightingSystemTests
+  {
+    private static Moveable CreateMoveable(string id, int weaponSkill, int weaponDamage = 8, int toughness = 100, int armour = 0, int wounds = 1000)
+    {
+      var type = new MoveableType(
+          id: id,
+          name: id,
+          animationClass: "animated_test",
+          asciiCharacter: "t",
+          asciiColour: "white",
+          weaponSkill: weaponSkill,
+          weaponDamage: weaponDamage,
+          toughness: toughness,
+          armour: armour,
+          wounds: wounds);
+
+      return new Moveable(0, 0, aIComponent: null, type);
+    }
+
+    [Fact]
+    public void CloseCombatAttack_ThrowsForNullAttacker()
+    {
+      var fightingSystem = new FightingSystem(game: null!);
+      var defender = CreateMoveable("defender", 30);
+
+      Assert.Throws<ArgumentNullException>(() => fightingSystem.CloseCombatAttack(null!, defender.CombatComponent!));
+    }
+
+    [Fact]
+    public void CloseCombatAttack_ThrowsForNullDefender()
+    {
+      var fightingSystem = new FightingSystem(game: null!);
+      var attacker = CreateMoveable("attacker", 30);
+
+      Assert.Throws<ArgumentNullException>(() => fightingSystem.CloseCombatAttack(attacker.CombatComponent!, null!));
+    }
+
+    [Fact]
+    public void CloseCombatAttack_HigherWeaponSkillWinsMoreOftenOverManyRounds()
+    {
+      // High toughness/wounds so nobody actually dies mid-way through the sample, which would
+      // otherwise stop generating attacks against that combatant (a fresh dummy is used per round instead).
+      var fightingSystem = new FightingSystem(game: null!);
+
+      const int rounds = 2000;
+      int strongAttackerHits = 0;
+      int weakAttackerHits = 0;
+
+      for (int i = 0; i < rounds; i++)
+      {
+        var strongAttacker = CreateMoveable("strong", weaponSkill: 70);
+        var weakDefender = CreateMoveable("weakDefender", weaponSkill: 20);
+        if (fightingSystem.CloseCombatAttack(strongAttacker.CombatComponent!, weakDefender.CombatComponent!))
+        {
+          strongAttackerHits++;
+        }
+
+        var weakAttacker = CreateMoveable("weak", weaponSkill: 20);
+        var strongDefender = CreateMoveable("strongDefender", weaponSkill: 70);
+        if (fightingSystem.CloseCombatAttack(weakAttacker.CombatComponent!, strongDefender.CombatComponent!))
+        {
+          weakAttackerHits++;
+        }
+      }
+
+      Assert.True(
+          strongAttackerHits > weakAttackerHits,
+          $"Expected an attacker with much higher weapon skill to land more hits ({strongAttackerHits}) than one with much lower weapon skill ({weakAttackerHits}) over {rounds} rounds.");
+    }
+  }
+}

--- a/BlazorRogue.Tests/ConfigurationTests.cs
+++ b/BlazorRogue.Tests/ConfigurationTests.cs
@@ -62,7 +62,7 @@ namespace BlazorRogue.Tests
     }
 
     [Fact]
-    public void Parse_ThrowsOnDuplicateFloorSetId()
+    public void Parse_LoadedFloorSetIdsAreUnique()
     {
       // Configuration.Parse() reads from the real Data files, so we cover the duplicate-id guard
       // indirectly here by asserting all currently-loaded floor set ids are unique - a duplicate

--- a/BlazorRogue.Tests/ConfigurationTests.cs
+++ b/BlazorRogue.Tests/ConfigurationTests.cs
@@ -1,0 +1,77 @@
+using BlazorRogue.Entities;
+
+namespace BlazorRogue.Tests
+{
+  public class ConfigurationTests
+  {
+    private static Configuration ParseConfiguration()
+    {
+      var configuration = new Configuration();
+      configuration.Parse();
+      return configuration;
+    }
+
+    [Fact]
+    public void Parse_LoadsAllKnownMonsterTypes()
+    {
+      var configuration = ParseConfiguration();
+
+      Assert.True(configuration.MonsterTypes.ContainsKey("skeleton"));
+      Assert.True(configuration.MonsterTypes.ContainsKey("goblin"));
+      Assert.True(configuration.MonsterTypes.ContainsKey("ogre"));
+    }
+
+    [Fact]
+    public void Parse_MonsterStatsMatchDataFile()
+    {
+      var configuration = ParseConfiguration();
+
+      var ogre = configuration.MonsterTypes["ogre"];
+      Assert.Equal("Ogre", ogre.Name);
+      Assert.Equal(30, ogre.WeaponSkill);
+      Assert.Equal(10, ogre.WeaponDamage);
+      Assert.Equal(45, ogre.Toughness);
+      Assert.Equal(2, ogre.Armour);
+      Assert.Equal(17, ogre.Wounds);
+    }
+
+    [Fact]
+    public void Parse_LoadsHeroTypes()
+    {
+      var configuration = ParseConfiguration();
+
+      Assert.True(configuration.HeroTypes.ContainsKey("templar"));
+      Assert.Equal("Templar", configuration.HeroTypes["templar"].Name);
+    }
+
+    [Fact]
+    public void Parse_LoadsFloorAndWallSets()
+    {
+      var configuration = ParseConfiguration();
+
+      Assert.NotEmpty(configuration.StandardFloorSets);
+      Assert.NotEmpty(configuration.DungeonWallSets);
+    }
+
+    [Fact]
+    public void Parse_LoadsStaticDecorativeObjectTypes()
+    {
+      var configuration = ParseConfiguration();
+
+      Assert.NotEmpty(configuration.StaticDecorativeObjectTypes);
+    }
+
+    [Fact]
+    public void Parse_ThrowsOnDuplicateFloorSetId()
+    {
+      // Configuration.Parse() reads from the real Data files, so we cover the duplicate-id guard
+      // indirectly here by asserting all currently-loaded floor set ids are unique - a duplicate
+      // would previously have caused Parse() itself to throw before we ever got here.
+      var configuration = ParseConfiguration();
+      var ids = configuration.StandardFloorSets.Select(t => t.Id)
+          .Concat(configuration.SpecialFloorSets.Select(t => t.Id));
+
+      Assert.Equal(ids.Count(), ids.Distinct().Count());
+    }
+  }
+}

--- a/BlazorRogue.Tests/GameTests.cs
+++ b/BlazorRogue.Tests/GameTests.cs
@@ -1,0 +1,39 @@
+namespace BlazorRogue.Tests
+{
+  /// <summary>
+  /// End-to-end smoke tests that exercise Configuration parsing + procedural dungeon generation
+  /// together, since these are the pieces most likely to break silently (e.g. bad JSON data,
+  /// generation getting stuck) without a human noticing until the app is run manually.
+  /// </summary>
+  public class GameTests
+  {
+    [Fact]
+    public void NewGame_GeneratesAPlayableMapWithAPlacedPlayer()
+    {
+      var game = new Game();
+
+      Assert.NotNull(game.Map);
+      Assert.NotNull(game.Map.Player);
+      Assert.InRange(game.Map.Player.x, 0, game.Map.Width - 1);
+      Assert.InRange(game.Map.Player.y, 0, game.Map.Height - 1);
+
+      // The underlying tile the player starts on must not itself be a blocking (e.g. wall/void)
+      // tile, or the game would be unplayable from the start. Note: Map.IsBlocked() on the
+      // player's own coordinates is expected to be true here, since a Moveable standing on a
+      // tile marks that tile as blocked for movement purposes (see Map.UpdateBlockMovement()).
+      Assert.False(game.Map.Tiles[game.Map.Player.x, game.Map.Player.y].Blocking);
+    }
+
+    [Fact]
+    public void NewGame_CanBeGeneratedRepeatedlyWithoutThrowing()
+    {
+      // Dungeon generation involves randomness; run it several times to catch intermittent bugs
+      // (e.g. generation logic that occasionally produces an invalid or unreachable layout).
+      for (int i = 0; i < 5; i++)
+      {
+        var game = new Game();
+        Assert.NotNull(game.Map.Player);
+      }
+    }
+  }
+}

--- a/BlazorRogue.Tests/MapTests.cs
+++ b/BlazorRogue.Tests/MapTests.cs
@@ -1,0 +1,102 @@
+using BlazorRogue.Entities;
+
+namespace BlazorRogue.Tests
+{
+  public class MapTests
+  {
+    private static Map CreateMap(int width = 10, int height = 10)
+    {
+      var wallSet = new TileSet("test_wall", TileType.Wall, "test", new[] { 0 });
+      return new Map(width, height, wallSet, game: null!);
+    }
+
+    [Theory]
+    [InlineData(0, 0, 0)]
+    [InlineData(3, 4, 5)]
+    [InlineData(6, 8, 10)]
+    public void GetDistance_ComputesEuclideanDistanceTruncated(int dx, int dy, int expected)
+    {
+      Assert.Equal(expected, Map.GetDistance(dx, dy));
+    }
+
+    [Theory]
+    [InlineData(0, 0, 0)]
+    [InlineData(3, 4, 25)]
+    [InlineData(-3, 4, 25)]
+    public void GetDistanceSquared_ComputesSquaredDistance(int dx, int dy, int expected)
+    {
+      Assert.Equal(expected, Map.GetDistanceSquared(dx, dy));
+    }
+
+    [Fact]
+    public void ForEachTile_VisitsEveryTileExactlyOnce()
+    {
+      var map = CreateMap(width: 4, height: 3);
+      var visited = new List<(int x, int y)>();
+
+      map.ForEachTile((x, y) => visited.Add((x, y)));
+
+      Assert.Equal(12, visited.Count);
+      Assert.Equal(12, visited.Distinct().Count());
+      Assert.Contains((0, 0), visited);
+      Assert.Contains((3, 2), visited);
+    }
+
+    [Fact]
+    public void ForEachTile_ClipsBoundsToMapDimensions()
+    {
+      var map = CreateMap(width: 5, height: 5);
+      var visited = new List<(int x, int y)>();
+
+      // Requesting a much larger area than the map should silently clip, not throw.
+      map.ForEachTile((x, y) => visited.Add((x, y)), xMin: -10, xMax: 100, yMin: -10, yMax: 100);
+
+      Assert.Equal(25, visited.Count);
+    }
+
+    [Fact]
+    public void BlocksLight_ReturnsTrueOutsideMapBounds()
+    {
+      var map = CreateMap(width: 5, height: 5);
+
+      Assert.True(map.BlocksLight(-1, 0));
+      Assert.True(map.BlocksLight(0, -1));
+      Assert.True(map.BlocksLight(5, 0));
+      Assert.True(map.BlocksLight(0, 5));
+    }
+
+    [Fact]
+    public void SetVisible_MarksTileAsVisibleAndMapped()
+    {
+      var map = CreateMap();
+
+      map.SetVisible(2, 3);
+
+      Assert.True(map.IsVisibleMap[2, 3]);
+      Assert.True(map.IsMappedMap[2, 3]);
+    }
+
+    [Fact]
+    public void SetVisible_OutOfBoundsIsANoOp()
+    {
+      var map = CreateMap(width: 5, height: 5);
+
+      // Should not throw despite being out of bounds.
+      map.SetVisible(-1, 0);
+      map.SetVisible(0, 10);
+    }
+
+    [Fact]
+    public void IsBlocked_BeforePostGenInitialize_ReflectsTileBlockingState()
+    {
+      var map = CreateMap();
+
+      // Tiles start out as blocking "dark" placeholder tiles until dungeon generation carves them out.
+      Assert.True(map.IsBlocked(2, 2));
+
+      map.Tiles[2, 2].Blocking = false;
+
+      Assert.False(map.IsBlocked(2, 2));
+    }
+  }
+}

--- a/BlazorRogue.Tests/TestSupport/FakeJsRuntime.cs
+++ b/BlazorRogue.Tests/TestSupport/FakeJsRuntime.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.JSInterop;
+
+namespace BlazorRogue.Tests.TestSupport
+{
+  /// <summary>
+  /// No-op <see cref="IJSRuntime"/> used so that code paths going through <see cref="SoundManager"/>
+  /// (e.g. GameObject.Kill(), Moveable.Move()) can run in tests without a real Blazor JS host.
+  /// </summary>
+  internal sealed class FakeJsRuntime : IJSRuntime
+  {
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+    {
+      return ValueTask.FromResult(default(TValue)!);
+    }
+
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args)
+    {
+      return ValueTask.FromResult(default(TValue)!);
+    }
+  }
+
+  /// <summary>
+  /// Ensures BlazorRogue's static <see cref="References"/> hub has a working (fake)
+  /// <see cref="SoundManager"/> before any test runs, since many game classes reach it directly
+  /// rather than through DI (see GameObject.Kill(), Moveable.Move()).
+  /// </summary>
+  internal static class AssemblySetup
+  {
+    [ModuleInitializer]
+    public static void Initialize()
+    {
+      References.SoundManager = new SoundManager(new FakeJsRuntime());
+    }
+  }
+}

--- a/BlazorRogue.Tests/UtilityMethodsTests.cs
+++ b/BlazorRogue.Tests/UtilityMethodsTests.cs
@@ -1,0 +1,28 @@
+namespace BlazorRogue.Tests
+{
+  public class UtilityMethodsTests
+  {
+    [Theory]
+    [InlineData("goblin", "Goblin")]
+    [InlineData("Goblin", "Goblin")]
+    [InlineData("g", "G")]
+    [InlineData("ALREADY", "ALREADY")]
+    public void FirstLetterToUpperCase_CapitalizesOnlyFirstCharacter(string input, string expected)
+    {
+      Assert.Equal(expected, input.FirstLetterToUpperCase());
+    }
+
+    [Fact]
+    public void FirstLetterToUpperCase_ReturnsEmptyStringForNull()
+    {
+      string? input = null;
+      Assert.Equal(string.Empty, input!.FirstLetterToUpperCase());
+    }
+
+    [Fact]
+    public void FirstLetterToUpperCase_ReturnsEmptyStringForEmpty()
+    {
+      Assert.Equal(string.Empty, "".FirstLetterToUpperCase());
+    }
+  }
+}

--- a/BlazorRogue.csproj
+++ b/BlazorRogue.csproj
@@ -13,4 +13,18 @@
     <Folder Include="wwwroot\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- BlazorRogue.Tests lives in a subfolder of this project; exclude it from the Web SDK's
+         default recursive globbing so its files aren't compiled into this project too. -->
+    <Compile Remove="BlazorRogue.Tests\**" />
+    <Content Remove="BlazorRogue.Tests\**" />
+    <None Remove="BlazorRogue.Tests\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Allows the test project to set internal-setter statics like References.SoundManager,
+         mirroring how app code (e.g. Pages/Indoor.razor) wires them up at runtime. -->
+    <InternalsVisibleTo Include="BlazorRogue.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/BlazorRogue.sln
+++ b/BlazorRogue.sln
@@ -5,16 +5,42 @@ VisualStudioVersion = 16.0.29025.244
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorRogue", "BlazorRogue.csproj", "{784648C6-D48B-48DA-AF96-208FB1FD8A7C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BlazorRogue.Tests", "BlazorRogue.Tests\BlazorRogue.Tests.csproj", "{F354FAFD-C6D3-42FB-939B-01D6A1ED5D41}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{784648C6-D48B-48DA-AF96-208FB1FD8A7C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{784648C6-D48B-48DA-AF96-208FB1FD8A7C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{784648C6-D48B-48DA-AF96-208FB1FD8A7C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{784648C6-D48B-48DA-AF96-208FB1FD8A7C}.Debug|x64.Build.0 = Debug|Any CPU
+		{784648C6-D48B-48DA-AF96-208FB1FD8A7C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{784648C6-D48B-48DA-AF96-208FB1FD8A7C}.Debug|x86.Build.0 = Debug|Any CPU
 		{784648C6-D48B-48DA-AF96-208FB1FD8A7C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{784648C6-D48B-48DA-AF96-208FB1FD8A7C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{784648C6-D48B-48DA-AF96-208FB1FD8A7C}.Release|x64.ActiveCfg = Release|Any CPU
+		{784648C6-D48B-48DA-AF96-208FB1FD8A7C}.Release|x64.Build.0 = Release|Any CPU
+		{784648C6-D48B-48DA-AF96-208FB1FD8A7C}.Release|x86.ActiveCfg = Release|Any CPU
+		{784648C6-D48B-48DA-AF96-208FB1FD8A7C}.Release|x86.Build.0 = Release|Any CPU
+		{F354FAFD-C6D3-42FB-939B-01D6A1ED5D41}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F354FAFD-C6D3-42FB-939B-01D6A1ED5D41}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F354FAFD-C6D3-42FB-939B-01D6A1ED5D41}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F354FAFD-C6D3-42FB-939B-01D6A1ED5D41}.Debug|x64.Build.0 = Debug|Any CPU
+		{F354FAFD-C6D3-42FB-939B-01D6A1ED5D41}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F354FAFD-C6D3-42FB-939B-01D6A1ED5D41}.Debug|x86.Build.0 = Debug|Any CPU
+		{F354FAFD-C6D3-42FB-939B-01D6A1ED5D41}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F354FAFD-C6D3-42FB-939B-01D6A1ED5D41}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F354FAFD-C6D3-42FB-939B-01D6A1ED5D41}.Release|x64.ActiveCfg = Release|Any CPU
+		{F354FAFD-C6D3-42FB-939B-01D6A1ED5D41}.Release|x64.Build.0 = Release|Any CPU
+		{F354FAFD-C6D3-42FB-939B-01D6A1ED5D41}.Release|x86.ActiveCfg = Release|Any CPU
+		{F354FAFD-C6D3-42FB-939B-01D6A1ED5D41}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -65,7 +65,13 @@ dotnet run
 
 By default the app listens on `https://localhost:5001` and `http://localhost:5000` (see `Properties/launchSettings.json`) — open either URL in a browser to play. There's no database or seed step; a fresh dungeon is generated on every page load.
 
-There is no test project in this repository (`dotnet test` has nothing to run) and no separate lint step — rely on `.editorconfig` conventions and the compiler's nullable-reference-type warnings (the build is currently warning-free; please keep it that way). CI runs `dotnet build` on every push/PR to `master` via GitHub Actions (`.github/workflows/build.yml`).
+`BlazorRogue.Tests` is an xUnit test project covering core, UI-independent game logic (dice/combat math, `Configuration` JSON parsing, `Map` geometry helpers, and end-to-end dungeon generation smoke tests). Run it with:
+
+```
+dotnet test
+```
+
+There is no separate lint step — rely on `.editorconfig` conventions and the compiler's nullable-reference-type warnings (the build is currently warning-free; please keep it that way). CI runs `dotnet build` followed by `dotnet test` on every push/PR to `master` via GitHub Actions (`.github/workflows/build.yml`).
 
 (This very project started with a `dotnet new blazorserverside -o WebApplication1`, as can probably still be seen here and there.)
 
@@ -89,6 +95,7 @@ If you own the UF Tileset, put the subfolders of the `uf_split` folder from the 
 
 ```
 BlazorRogue.csproj / Program.cs   Minimal-hosting entry point, unified Blazor Components hosting
+BlazorRogue.Tests/                xUnit test project for core game-logic classes (see below)
 App.razor / Routes.razor          Root HTML shell + router
 Pages/                            Blazor pages (Indoor.razor is the main game view)
 Shared/                           Shared Razor components
@@ -127,9 +134,9 @@ These are parsed in `Configuration.cs` via a `Parse*Type` method per entity kind
 
 ## Contributing
 
-- `master` is protected: everyone (including the maintainer) needs to go through a pull request; CI (`dotnet build`) must pass before merging.
+- `master` is protected: everyone (including the maintainer) needs to go through a pull request; CI (`dotnet build` + `dotnet test`) must pass before merging.
 - Please keep the build warning-free — nullable reference types are enabled project-wide.
-- Since there's no test suite yet, please describe how you manually verified a change (e.g. build + a screenshot or a description of in-browser testing) in your PR description.
+- Add or update tests in `BlazorRogue.Tests` for changes to game logic (combat, configuration parsing, map/dungeon generation, etc.); for changes that are hard to unit test (rendering, Blazor components, JS interop), please describe how you manually verified the change (e.g. a screenshot or a description of in-browser testing) in your PR description.
 - Small, focused PRs are preferred over large ones, especially for anything touching rendering or the hosting model — those are the areas most likely to have subtle runtime-only breakage that `dotnet build` won't catch.
 
 ## License


### PR DESCRIPTION

## What's covered (56 tests)

- **Dice** (`Combat/DiceTests.cs`) — d100 roll range, digit reversal, success-level math.
- **CombatComponent** (`Combat/CombatComponentTests.cs`) — damage/toughness/armour math, advantage cap/reset, death-on-zero-wounds. Includes a test documenting a pre-existing quirk: when soaked damage (toughness bonus + armour) exceeds raw damage, wounds actually increase rather than being floored at 0.
- **FightingSystem** (`Combat/FightingSystemTests.cs`) — null-argument guards, and a statistical check that a much higher weapon skill wins more often over many rounds.
- **Configuration** (`ConfigurationTests.cs`) — parses the real `Data/*.json` files and asserts monster/hero stats and floor/wall/decoration sets load correctly, plus the duplicate-id guard.
- **Map** (`MapTests.cs`) — distance helpers, `ForEachTile` bounds-clipping, `BlocksLight`/`SetVisible` out-of-bounds handling, `IsBlocked`.
- **UtilityMethods** (`UtilityMethodsTests.cs`) — string extension edge cases (null/empty/already-capitalized).
- **Game** (`GameTests.cs`) — end-to-end smoke test: `new Game()` (Configuration parse + procedural dungeon generation) repeatedly produces a valid map with a properly placed player, without throwing.

## Infrastructure

- `BlazorRogue.csproj`: excludes the nested `BlazorRogue.Tests` folder from its own file globbing (Web SDK globs recursively by default), and adds `InternalsVisibleTo` for `BlazorRogue.Tests` so tests can set `References.SoundManager` the same way `Pages/Indoor.razor` does at runtime.
- A `FakeJsRuntime` (`TestSupport/FakeJsRuntime.cs`) is wired up via a `[ModuleInitializer]` so code paths that go through `SoundManager` (e.g. `GameObject.Kill()`) work without a real Blazor JS host.
- Test project mirrors `Data/*.json` into its own output directory, since `Configuration.Parse()` reads them via relative "Data\..." paths.
- `[assembly: CollectionBehavior(DisableTestParallelization = true)]` — this codebase uses static global state (`References`) rather than DI in several places, so tests that touch it run sequentially to avoid cross-test interference.
- `BlazorRogue.Tests` added to the `.sln`.
- `.github/workflows/build.yml` now runs `dotnet test` after `dotnet build`.
- `README.md` and `.github/copilot-instructions.md` updated to reflect the new test project and drop the "no tests" language.

## Verification

- `dotnet build --configuration Release` — 0 warnings, 0 errors.
- `dotnet test --configuration Release` — 56/56 passed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

